### PR TITLE
Apply geolocation to all route pairs, not just the active tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ A web scraper that fetches daily train timetables from [Elron](https://elron.pil
 - Laagri → Tallinn
 - Tallinn → Laagri
 
+## Using the Timetable
+
+Open `timetable.html` (e.g. via GitHub Pages or by hosting the file anywhere static) on your phone or desktop. Everything runs client-side — no server, no spinners.
+
+### Pick a route
+- **Tabs** at the top switch between route pairs (Laagri ↔ Tallinn, Kivimäe ↔ Laagri).
+- **Swap button (⇄)** flips the direction of the current pair.
+
+### Auto-detect the closest station
+On first load the page asks for your location. If allowed, every route pair is oriented so the station nearest you is the *from* station — e.g. if you're in Laagri you'll see "Laagri → Tallinn" and "Laagri → Kivimäe" on their respective tabs without having to swap. Your location is used only in-browser and cached for 30 minutes; it is never sent anywhere.
+
+### See the next train at a glance
+- The **hero card** at the top shows a live countdown to the next departure (`12m`, `1h 04m`, …) plus the departure → arrival time and train number.
+- Each row in the list also has its own countdown that ticks every minute.
+- Color cues: **green** = leaves within 15 minutes, **blue** = next upcoming, faded = already departed.
+
+### Filter and remember
+- **Future only** toggle hides trains that have already left; flip it off to see the full day.
+- Your last picked tab and direction are remembered, so coming back to the page lands you where you left off.
+
 ## How It Works
 
 1. A GitHub Actions workflow runs daily at 03:00 UTC (can also be triggered manually)

--- a/RailScraper.py
+++ b/RailScraper.py
@@ -472,6 +472,7 @@ class RailScraper:
 
         let activePairIndex = 0;
         let activeDirectionIndex = 0; // 0 = first direction, 1 = second
+        let pairDirections = []; // per-pair preferred direction index
         let showFutureOnly = true;
 
         // --- Geolocation & Persistence ---
@@ -501,32 +502,38 @@ class RailScraper:
 
         function applyGeoSelection(lat, lng) {{
             let bestPairIdx = 0;
-            let bestDirIdx = 0;
             let bestDist = Infinity;
 
+            // For every pair, choose the direction whose "from" station is
+            // closest to the user. The pair containing the overall nearest
+            // station becomes the active tab.
             DATA.route_pairs.forEach((pair, pi) => {{
                 const dirKeys = Object.keys(pair.directions);
-                pair.stations.forEach((stId, si) => {{
-                    const st = DATA.stations[stId];
+                let pairBestDirIdx = 0;
+                let pairBestDist = Infinity;
+                dirKeys.forEach((key, di) => {{
+                    const fromId = pair.directions[key].from;
+                    const st = DATA.stations[fromId];
                     const d = haversine(lat, lng, st.lat, st.lng);
-                    if (d < bestDist) {{
-                        bestDist = d;
-                        bestPairIdx = pi;
-                        // direction where this station is the "from"
-                        bestDirIdx = dirKeys.findIndex(k => pair.directions[k].from === stId);
-                        if (bestDirIdx === -1) bestDirIdx = 0;
+                    if (d < pairBestDist) {{
+                        pairBestDist = d;
+                        pairBestDirIdx = di;
                     }}
                 }});
+                pairDirections[pi] = pairBestDirIdx;
+                if (pairBestDist < bestDist) {{
+                    bestDist = pairBestDist;
+                    bestPairIdx = pi;
+                }}
             }});
 
             activePairIndex = bestPairIdx;
-            activeDirectionIndex = bestDirIdx;
+            activeDirectionIndex = pairDirections[activePairIndex];
 
-            // Cache
             try {{
                 localStorage.setItem('railscraper_geo', JSON.stringify({{
                     pair: activePairIndex,
-                    dir: activeDirectionIndex,
+                    pairDirs: pairDirections,
                     ts: Date.now()
                 }}));
             }} catch(e) {{}}
@@ -540,7 +547,8 @@ class RailScraper:
                 const geo = JSON.parse(localStorage.getItem('railscraper_geo'));
                 if (geo && (Date.now() - geo.ts) < GEO_TTL) {{
                     activePairIndex = geo.pair;
-                    activeDirectionIndex = geo.dir;
+                    if (Array.isArray(geo.pairDirs)) pairDirections = geo.pairDirs;
+                    activeDirectionIndex = pairDirections[activePairIndex] ?? geo.dir ?? 0;
                     return;
                 }}
             }} catch(e) {{}}
@@ -564,7 +572,8 @@ class RailScraper:
                 const last = JSON.parse(localStorage.getItem('railscraper_last_pair'));
                 if (last) {{
                     activePairIndex = last.pair;
-                    activeDirectionIndex = last.dir;
+                    if (Array.isArray(last.pairDirs)) pairDirections = last.pairDirs;
+                    activeDirectionIndex = pairDirections[activePairIndex] ?? last.dir ?? 0;
                 }}
             }} catch(e) {{}}
         }}
@@ -573,7 +582,8 @@ class RailScraper:
             try {{
                 localStorage.setItem('railscraper_last_pair', JSON.stringify({{
                     pair: activePairIndex,
-                    dir: activeDirectionIndex
+                    dir: activeDirectionIndex,
+                    pairDirs: pairDirections
                 }}));
             }} catch(e) {{}}
         }}
@@ -597,7 +607,7 @@ class RailScraper:
                 tab.textContent = pair.label;
                 tab.onclick = () => {{
                     activePairIndex = i;
-                    activeDirectionIndex = 0;
+                    activeDirectionIndex = pairDirections[i] ?? 0;
                     saveManualChoice();
                     renderAll();
                 }};
@@ -616,6 +626,7 @@ class RailScraper:
             const pair = getActivePair();
             const keys = Object.keys(pair.directions);
             activeDirectionIndex = (activeDirectionIndex + 1) % keys.length;
+            pairDirections[activePairIndex] = activeDirectionIndex;
             saveManualChoice();
             renderAll();
         }}


### PR DESCRIPTION
## Summary
- Geolocation now sets the preferred direction for **every** route pair, so switching tabs always shows the nearer station as "from".
- Per-pair direction is persisted (geo cache + manual swaps) so user overrides stick per pair instead of being reset to index 0 on tab change.

## Why
Reported by a user: closest station was Laagri, default tab opened "Laagri → Tallinn" correctly, but switching tabs showed "Kivimäe → Laagri" (the old default). They read the wrong departure time and missed their train.

## Test plan
- [ ] Clear localStorage, allow geolocation when nearest to Laagri → both tabs show "Laagri → ..." direction
- [ ] Clear localStorage, allow geolocation when nearest to Kivimäe → Kivimäe pair opens "Kivimäe → Laagri", Laagri pair opens "Laagri → Tallinn"
- [ ] Manually swap one pair, switch tabs, switch back → swap is remembered
- [ ] Deny geolocation → falls back to last saved preference (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)