### PR TITLE
Add Nõmme↔Tallinn and Lilleküla↔Nõmme routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-RailScraper is a Python web scraper that fetches Estonian rail (Elron) timetables for three route pairs (Laagri↔Tallinn, Kivimäe↔Laagri, Rahumäe↔Tallinn) and generates a static HTML timetable page. It runs daily via GitHub Actions (cron at 03:00 UTC) and commits the updated `timetable.html` and `timetable_data.json` back to the repo.
+RailScraper is a Python web scraper that fetches Estonian rail (Elron) timetables for five route pairs (Laagri↔Tallinn, Kivimäe↔Laagri, Rahumäe↔Tallinn, Nõmme↔Tallinn, Lilleküla↔Nõmme) and generates a static HTML timetable page. It runs daily via GitHub Actions (cron at 03:00 UTC) and commits the updated `timetable.html` and `timetable_data.json` back to the repo.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ A web scraper that fetches daily train timetables from [Elron](https://elron.pil
 - Laagri ↔ Tallinn
 - Kivimäe ↔ Laagri
 - Rahumäe ↔ Tallinn
+- Nõmme ↔ Tallinn
+- Lilleküla ↔ Nõmme
 
 ## Using the Timetable
 
 Open [`timetable.html`](https://hanskan89.github.io/RailScraper/timetable.html) (e.g. via GitHub Pages or by hosting the file anywhere static) on your phone or desktop. Everything runs client-side — no server, no spinners.
 
 ### Pick a route
-- **Tabs** at the top switch between route pairs (Laagri ↔ Tallinn, Kivimäe ↔ Laagri, Rahumäe ↔ Tallinn). On narrow phones the tab strip scrolls horizontally; the active tab auto-centers in view.
+- **Tabs** at the top switch between route pairs (Laagri ↔ Tallinn, Kivimäe ↔ Laagri, Rahumäe ↔ Tallinn, Nõmme ↔ Tallinn, Lilleküla ↔ Nõmme). On narrow phones the tab strip scrolls horizontally; the active tab auto-centers in view.
 - **Swap button (⇄)** flips the direction of the current pair.
 
 ### Auto-detect the closest station

--- a/RailScraper.py
+++ b/RailScraper.py
@@ -62,10 +62,12 @@ class RailScraper:
         """Load configuration from JSON file."""
         default_config = {
             "stations": {
-                "laagri":   {"name": "Laagri",   "lat": 59.3544, "lng": 24.6275},
-                "kivimae":  {"name": "Kivimäe",  "lat": 59.3770, "lng": 24.6566},
-                "rahumae":  {"name": "Rahumäe",  "lat": 59.3888, "lng": 24.7044},
-                "tallinn":  {"name": "Tallinn",  "lat": 59.4400, "lng": 24.7375}
+                "laagri":    {"name": "Laagri",    "lat": 59.3544, "lng": 24.6275},
+                "kivimae":   {"name": "Kivimäe",   "lat": 59.3770, "lng": 24.6566},
+                "rahumae":   {"name": "Rahumäe",   "lat": 59.3888, "lng": 24.7044},
+                "nomme":     {"name": "Nõmme",     "lat": 59.3861, "lng": 24.6863},
+                "lillekula": {"name": "Lilleküla", "lat": 59.4248, "lng": 24.7280},
+                "tallinn":   {"name": "Tallinn",   "lat": 59.4400, "lng": 24.7375}
             },
             "route_pairs": [
                 {
@@ -95,6 +97,26 @@ class RailScraper:
                     "url_templates": {
                         "rahumae-tallinn": "https://elron.pilet.ee/et/otsing/Rahum%C3%A4e/Tallinn/{date}",
                         "tallinn-rahumae": "https://elron.pilet.ee/et/otsing/Tallinn/Rahum%C3%A4e/{date}"
+                    },
+                    "selectors": {"trip_container": ".trip-summary__timespan"}
+                },
+                {
+                    "id": "nomme-tallinn",
+                    "label": "Nõmme ↔ Tallinn",
+                    "stations": ["nomme", "tallinn"],
+                    "url_templates": {
+                        "nomme-tallinn": "https://elron.pilet.ee/et/otsing/N%C3%B5mme/Tallinn/{date}",
+                        "tallinn-nomme": "https://elron.pilet.ee/et/otsing/Tallinn/N%C3%B5mme/{date}"
+                    },
+                    "selectors": {"trip_container": ".trip-summary__timespan"}
+                },
+                {
+                    "id": "lillekula-nomme",
+                    "label": "Lilleküla ↔ Nõmme",
+                    "stations": ["lillekula", "nomme"],
+                    "url_templates": {
+                        "lillekula-nomme": "https://elron.pilet.ee/et/otsing/Lillek%C3%BCla/N%C3%B5mme/{date}",
+                        "nomme-lillekula": "https://elron.pilet.ee/et/otsing/N%C3%B5mme/Lillek%C3%BCla/{date}"
                     },
                     "selectors": {"trip_container": ".trip-summary__timespan"}
                 }


### PR DESCRIPTION
## Summary
- Two new route pairs (`nomme-tallinn`, `lillekula-nomme`), wired into `default_config` exactly like the existing `rahumae-tallinn` entry
- New `nomme` and `lillekula` stations with user-verified GPS so the geolocation auto-direction logic picks them up
- README + CLAUDE.md updated from "three" to "five" route pairs

## Test plan
- [ ] Trigger the GitHub Actions workflow manually and confirm the next `Update timetables` commit includes data for `nomme-tallinn` and `lillekula-nomme`
- [ ] Open the regenerated `timetable.html`, confirm both new tabs render and swap works in either direction
- [ ] From a device near Nõmme/Lilleküla, confirm geolocation orients the new tabs with the local station as *from*

🤖 Generated with [Claude Code](https://claude.com/claude-code)